### PR TITLE
Accept piped data

### DIFF
--- a/kubesort
+++ b/kubesort
@@ -8,6 +8,33 @@
 #uncomment next line for debugging
 # set -x
 
+# detect if the script is being piped to
+if [[ -p /dev/stdin ]]; then
+    # save the data from the pipe
+    PIPED_DATA=$(cat -)
+    SORT_ARG=$1
+fi
+
+# Use this function to sort piped data
+sort_pipe () {
+
+  # save our header information for later
+  # this script wouldn't work if --no-headers is used
+  HEADER=$(echo "$PIPED_DATA" | head -1)
+  # use the first arg or age by default
+  SORT_FIELD=${SORT_ARG:-AGE}
+
+  # find which column number our sort field is in.
+  # this should return a column number.
+  # grep is case insensitive
+  COLUMN=$(echo "$HEADER" | tr -s ' ' '\n' | nl | grep -i ${SORT_FIELD} | awk '{print $1}')
+
+  # echo header separate so `sort` doesn't try to move it
+  echo "$HEADER"
+  # echo the rest of our data. sorted and without header row
+  echo "$PIPED_DATA" |tail -n +2| sort -h -r -k $COLUMN
+}
+
 cmd=$4
 option3=$4
 [ -z "$cmd" ] && cmd="help";
@@ -66,6 +93,12 @@ cat << EOF
 EOF
 exit
 }
+
+# check for piped data. run our function if it's set
+if [ -n "${PIPED_DATA}" ]; then
+  sort_pipe
+  exit
+fi
 
 if [[ "$1" = "kubectl" && "$2" = "get" ]];
 then


### PR DESCRIPTION
Here is how I would want to use `kubesort`. Being able to pipe data into it in addition to using it as a command wrapper could be very useful.

Using bash and `sort` has some limitations but I think it mostly just works as expected (I didn't test every field)

You can run it without args and it'll default to AGE column
```
kubectl get po| ./kubesort
NAME                       READY   STATUS    RESTARTS   AGE
nginx2                     1/1     Running   1          29m
nginx                      1/1     Running   2          21h
postgres-0                 1/1     Running   0          4d4h
counter-7b58954fbf-zszkb   1/1     Running   0          4d4h
```

or run it with a column to sort.
```
kubectl get po| ./kubesort restarts
NAME                       READY   STATUS    RESTARTS   AGE
counter-7b58954fbf-zszkb   1/1     Running   0          4d4h
postgres-0                 1/1     Running   0          4d4h
nginx2                     1/1     Running   1          29m
nginx                      1/1     Running   2          21h
```

When you pipe data to it it doesn't limit what fields can be sorted but it does require you to use a header row because that's where it bases the sort argument from.

It might be good to handle tests in case the data is malformed or if `kubectl` spits out help text.